### PR TITLE
Add path tests

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -57,7 +57,14 @@ jobs:
     # BUILD
     - name: Build
       run: |
+        if [[ $VERSION_SUFFIX ]]; then
+          VERSION_SUFFIX_PARAM="--version-suffix sha.$VERSION_SUFFIX"
+        else
+          VERSION_SUFFIX_PARAM=''
+        fi
         dotnet build --configuration Release ${VERSION_SUFFIX_PARAM}
+      env:
+        VERSION_SUFFIX: ${{ github.ref != 'refs/heads/main' && github.sha || '' }}
 
     ###########
     # TEST

--- a/eng/pnpm.targets
+++ b/eng/pnpm.targets
@@ -95,11 +95,11 @@
         <PropertyGroup>
             <PackageJsonLastModifiedTime>$([System.IO.File]::GetLastWriteTime('package.json').ToString('g'))</PackageJsonLastModifiedTime>
         </PropertyGroup>
-        <Exec WorkingDirectory="$(ProjectDir)" Command="npm version $(Version)" IgnoreExitCode="true" />
+        <Exec WorkingDirectory="$(ProjectDir)" Command="npm version $(Version)" IgnoreExitCode="true" Condition=" '$(NpmPackageVersion)' != '$(Version)' " />
         <MakeDir Directories="$(PackageOutputPath)"/>
         <Exec WorkingDirectory="$(ProjectDir)" Command="pnpm pack" />
         <Move SourceFiles="$(NpmPackageNormalizedName)-$(Version).tgz" DestinationFolder="$(PackageOutputPath)" />
-        <Exec WorkingDirectory="$(ProjectDir)" Command="npm version $(NpmPackageVersion)" IgnoreExitCode="true" />
+        <Exec WorkingDirectory="$(ProjectDir)" Command="npm version $(NpmPackageVersion)" IgnoreExitCode="true" Condition=" '$(NpmPackageVersion)' != '$(Version)' " />
         <Touch Files="package.json" Time="$(PackageJsonLastModifiedTime)" />
     </Target>
 

--- a/eng/pnpm.targets
+++ b/eng/pnpm.targets
@@ -85,13 +85,22 @@
         <PropertyGroup>
             <NpmPackageNormalizedName>@(NpmPackageName->'%(Identity)'->Replace("@", "")->Replace("/", "-"))</NpmPackageNormalizedName>
             <NpmPackageVersion>@(NpmPackageVersion->'%(Identity)')</NpmPackageVersion>
+            <VersionPrefix>@(NpmPackageVersion->'%(Identity)')</VersionPrefix>
+            <Version>$(VersionPrefix)</Version>
+            <Version Condition=" '$(VersionSuffix)' != '' ">$(VersionPrefix)-$(VersionSuffix)</Version>
         </PropertyGroup>
     </Target>
 
     <Target Name="PnpmPack" BeforeTargets="Publish" DependsOnTargets="NodeBuild" Inputs="@(RestoreConfig);@(PnpmPackagedFiles);@(CompileOutputs)" Outputs="$(PackageOutputPath)$(NpmPackageNormalizedName)-$(NpmPackageVersion).tgz">
+        <PropertyGroup>
+            <PackageJsonLastModifiedTime>$([System.IO.File]::GetLastWriteTime('package.json').ToString('g'))</PackageJsonLastModifiedTime>
+        </PropertyGroup>
+        <Exec WorkingDirectory="$(ProjectDir)" Command="npm version $(Version)" IgnoreExitCode="true" />
         <MakeDir Directories="$(PackageOutputPath)"/>
         <Exec WorkingDirectory="$(ProjectDir)" Command="pnpm pack" />
-        <Move SourceFiles="$(NpmPackageNormalizedName)-$(NpmPackageVersion).tgz" DestinationFolder="$(PackageOutputPath)" />
+        <Move SourceFiles="$(NpmPackageNormalizedName)-$(Version).tgz" DestinationFolder="$(PackageOutputPath)" />
+        <Exec WorkingDirectory="$(ProjectDir)" Command="npm version $(NpmPackageVersion)" IgnoreExitCode="true" />
+        <Touch Files="package.json" Time="$(PackageJsonLastModifiedTime)" />
     </Target>
 
     <Target Name="VSTest">

--- a/packages/react-jotai-forms/package.json
+++ b/packages/react-jotai-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@principlestudios/react-jotai-forms",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "👻 React Forms using Jotai",
 	"main": "dist/index.js",
 	"module": "dist/mjs/index.js",

--- a/packages/react-jotai-forms/src/internals/useFormHelpers.ts
+++ b/packages/react-jotai-forms/src/internals/useFormHelpers.ts
@@ -279,9 +279,7 @@ function toField<T, TPath extends Path<T>, TValue>(
 		disabled: substateAtom(config.disabled, context.disabledFields),
 		readOnly: substateAtom(config.readOnly, context.readOnlyFields),
 	};
-	const unmappedAtom = context.atomFamily(
-		config.path as Path<T>
-	) as StandardWritableAtom<PathValue<T, TPath>>;
+	const unmappedAtom = context.atomFamily(config.path);
 	const fieldResult = toInternalFieldAtom<PathValue<T, TPath>, TValue>(
 		context.store,
 		unmappedAtom,

--- a/packages/react-jotai-forms/src/internals/useFormHelpers.ts
+++ b/packages/react-jotai-forms/src/internals/useFormHelpers.ts
@@ -233,14 +233,19 @@ export function buildFormFields<
 >(fields: TFields, params: FormResultContext<T>): FormFields<T, TFields> {
 	return Object.fromEntries(
 		Object.entries(fields).map(([field, config]) => {
-			return [
-				field,
-				typeof config === 'function'
-					? (...args: AnyArray) =>
-							// eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-							buildFormField(config(...args), params)
-					: buildFormField(config, params),
-			];
+			if (typeof config === 'function') {
+				// TODO: Not sure why this needs a conversion, there should only be one function type here
+				return [
+					field,
+					(...args: AnyArray) =>
+						buildFormField(
+							(config as (...args: AnyArray) => BaseAnyFieldConfig<T>)(...args),
+							params
+						),
+				];
+			} else {
+				return [field, buildFormField(config, params)];
+			}
 		})
 	) as never as FormFields<T, TFields>;
 }

--- a/packages/react-jotai-forms/src/internals/useFormHelpers.ts
+++ b/packages/react-jotai-forms/src/internals/useFormHelpers.ts
@@ -279,7 +279,9 @@ function toField<T, TPath extends Path<T>, TValue>(
 		disabled: substateAtom(config.disabled, context.disabledFields),
 		readOnly: substateAtom(config.readOnly, context.readOnlyFields),
 	};
-	const unmappedAtom = context.atomFamily(config.path as Path<T>);
+	const unmappedAtom = context.atomFamily(
+		config.path as Path<T>
+	) as StandardWritableAtom<PathValue<T, TPath>>;
 	const fieldResult = toInternalFieldAtom<PathValue<T, TPath>, TValue>(
 		context.store,
 		unmappedAtom,

--- a/packages/react-jotai-forms/src/path.test.ts
+++ b/packages/react-jotai-forms/src/path.test.ts
@@ -73,6 +73,14 @@ describe('TypeScript path utilities', () => {
 			[] satisfies Path<Target>;
 			true satisfies IsExactType<PathValue<Target, []>, Target>;
 		});
+
+		function generic<T>() {
+			it('allows an arbitrary path with a T[]', () => {
+				[0] satisfies Path<T[]>;
+				true satisfies IsExactType<PathValue<T[], readonly [number]>, T>;
+			});
+		}
+		generic();
 	});
 
 	describe('primitive paths', () => {

--- a/packages/react-jotai-forms/src/path.test.ts
+++ b/packages/react-jotai-forms/src/path.test.ts
@@ -1,0 +1,93 @@
+import type { Path, PathValue } from './path';
+
+type IsExactType<A, B> = [A] extends [B]
+	? [B] extends [A]
+		? true
+		: false
+	: false;
+
+describe('TypeScript path utilities', () => {
+	/**
+	 * TS tests to demonstrate uses of paths - none of these jest tests assert
+	 * anything, but instead give TS errors if they are not correct */
+
+	describe('object paths', () => {
+		type Target = {
+			name: string;
+			bio: { age?: number };
+			items: { type: string }[];
+		};
+		it('can specify a regular path', () => {
+			['name'] satisfies Path<Target>;
+			true satisfies IsExactType<PathValue<Target, ['name']>, string>;
+		});
+
+		it('can specify a nested path', () => {
+			['bio', 'age'] satisfies Path<Target>;
+			true satisfies IsExactType<
+				PathValue<Target, ['bio', 'age']>,
+				number | undefined
+			>;
+		});
+
+		it('can specify an item in a nested array', () => {
+			['items', 0] satisfies Path<Target>;
+			true satisfies IsExactType<
+				PathValue<Target, ['items', 0]>,
+				{ type: string }
+			>;
+		});
+
+		it('can specify property within a nested array', () => {
+			['items', 0, 'type'] satisfies Path<Target>;
+			true satisfies IsExactType<
+				PathValue<Target, ['items', 0, 'type']>,
+				string
+			>;
+		});
+
+		it('allows an empty path', () => {
+			[] satisfies Path<Target>;
+			true satisfies IsExactType<PathValue<Target, []>, Target>;
+		});
+	});
+
+	describe('array paths', () => {
+		type Target = { type: string }[];
+		it('can specify which item in an array', () => {
+			[0] satisfies Path<Target>;
+			true satisfies IsExactType<PathValue<Target, [0]>, { type: string }>;
+		});
+		it('can specify a nested path', () => {
+			[0, 'type'] satisfies Path<Target>;
+			true satisfies IsExactType<PathValue<Target, [0, 'type']>, string>;
+		});
+		it('highlights errors', () => {
+			// @ts-expect-error type is not top level
+			['type'] satisfies Path<Target>;
+			// @ts-expect-error foo is not a nested property
+			[0, 'foo'] satisfies Path<Target>;
+		});
+
+		it('allows an empty path', () => {
+			[] satisfies Path<Target>;
+			true satisfies IsExactType<PathValue<Target, []>, Target>;
+		});
+	});
+
+	describe('primitive paths', () => {
+		type Target = string;
+
+		it('disallows properties on string', () => {
+			// @ts-expect-error length is not a valid property
+			['length'] satisfies Path<Target>;
+			// @ts-expect-error cannot access a character in a string
+			[0] satisfies Path<Target>;
+		});
+
+		it('allows an empty path', () => {
+			[] satisfies Path<Target>;
+			true satisfies IsExactType<PathValue<Target, []>, Target>;
+		});
+	});
+});

--- a/packages/react-jotai-forms/src/path.ts
+++ b/packages/react-jotai-forms/src/path.ts
@@ -70,13 +70,16 @@ type ArrayPathInternal<T, TraversedTypes = T> = T extends ReadonlyArray<infer V>
 	: {
 			[K in keyof T]-?: ArrayPathImpl<K & string, T[K], TraversedTypes>;
 	  }[keyof T];
-type ArrayPath<T> = T extends any ? ArrayPathInternal<T> : never;
 
-export type Path<T> = IfAny<T, any, T extends any ? PathInternal<T> : never>;
-export type PathValue<T, P extends Path<T> | ArrayPath<T>> = IfAny<
+export type Path<T> =
+	| []
+	| IfAny<T, any, T extends any ? PathInternal<T> : never>;
+export type PathValue<T, P extends Path<T>> = IfAny<
 	P,
 	any,
-	T extends any
+	P extends []
+		? T
+		: T extends any
 		? P extends readonly [infer K]
 			? K extends keyof T
 				? T[K]

--- a/packages/react-jotai-forms/src/useForm.primitive.test.tsx
+++ b/packages/react-jotai-forms/src/useForm.primitive.test.tsx
@@ -6,21 +6,18 @@ import { RenderResult, fireEvent, render } from '@testing-library/react';
 import { fastWaitFor } from './test/fastWaitFor';
 import { waitForErrors } from './test/waitForErrors';
 
-const myFormSchema = z.object({
-	name: z.string(),
-});
+const myFormSchema = z.string();
 type MyForm = z.infer<typeof myFormSchema>;
 type ComponentProps = { onSubmit: (data: MyForm) => void };
 
-const myFormSchemaWithValidation = z.object({
-	name: z.string().min(3).max(10),
-}) satisfies z.ZodSchema<MyForm>;
+const myFormSchemaWithValidation = z
+	.string()
+	.min(3)
+	.max(10) satisfies z.ZodSchema<MyForm>;
 
-const defaultValue: MyForm = {
-	name: '',
-};
+const defaultValue: MyForm = '';
 
-describe('useForm, inlineFields', () => {
+describe('useForm, primitive', () => {
 	function translation(key: string) {
 		return `translate: ${key}`;
 	}
@@ -45,7 +42,7 @@ describe('useForm, inlineFields', () => {
 					onSubmit(v);
 				})}
 			>
-				<JotaiInput {...form.field(['name']).htmlProps()} />
+				<JotaiInput {...form.field([]).htmlProps()} />
 				<button type="submit">Submit</button>
 			</form>
 		);
@@ -125,7 +122,7 @@ describe('useForm, inlineFields', () => {
 
 			const loadedErrors = (await waitForErrors(useFormResult.errors))!;
 			expect(loadedErrors.issues[0].code).toBe('too_small');
-			expect(loadedErrors.issues[0].path).toStrictEqual(['name']);
+			expect(loadedErrors.issues[0].path).toStrictEqual([]);
 		});
 
 		it('updates messages after submit on blur', async () => {
@@ -160,7 +157,7 @@ describe('useForm, inlineFields', () => {
 			});
 
 			it('receives form updates', () => {
-				expect(useFormResult.get().name).toBe('foobar');
+				expect(useFormResult.get()).toBe('foobar');
 			});
 
 			it('does not rerender', () => {
@@ -172,15 +169,13 @@ describe('useForm, inlineFields', () => {
 				fireEvent.click(submitButton);
 
 				await fastWaitFor(() => expect(submitSpy).toBeCalled());
-				expect(submitSpy).toBeCalledWith<[MyForm]>({
-					name: 'foobar',
-				});
+				expect(submitSpy).toBeCalledWith<[MyForm]>('foobar');
 			});
 		});
 
 		describe('when updated via the form result', () => {
 			beforeEach(() => {
-				useFormResult.set({ name: 'foobar' });
+				useFormResult.set('foobar');
 			});
 
 			it('updates the input', () => {
@@ -197,9 +192,7 @@ describe('useForm, inlineFields', () => {
 				fireEvent.click(submitButton);
 
 				await fastWaitFor(() => expect(submitSpy).toBeCalled());
-				expect(submitSpy).toBeCalledWith<[MyForm]>({
-					name: 'foobar',
-				});
+				expect(submitSpy).toBeCalledWith<[MyForm]>('foobar');
 			});
 		});
 	}


### PR DESCRIPTION
Adds tests to the path library, fixing a few very minor issues.

- Allows empty paths to refer to the current field, useful when mapping in-place
- Removes separate reference to array implementation in `PathValue<T, P>`, since that seemed to be causing issues

Also includes build tooling update to resolve #9 