### PR TITLE
Add support for post-mapping schemas

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Launch current Jest test file",
+			"type": "node-terminal",
+			"request": "launch",
+			"command": "pnpm jest ${fileBasename}",
+			"cwd": "${fileDirname}"
+		}
+	]
+}

--- a/packages/react-jotai-forms/package.json
+++ b/packages/react-jotai-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@principlestudios/react-jotai-forms",
-	"version": "0.1.2",
+	"version": "0.2.0",
 	"description": "👻 React Forms using Jotai",
 	"main": "dist/index.js",
 	"module": "dist/mjs/index.js",

--- a/packages/react-jotai-forms/src/internals/createErrorsAtom.ts
+++ b/packages/react-jotai-forms/src/internals/createErrorsAtom.ts
@@ -2,39 +2,45 @@ import type { Atom, WritableAtom } from 'jotai';
 import { atom } from 'jotai';
 import { loadable } from 'jotai/utils';
 import type { Loadable } from 'jotai/vanilla/utils/loadable';
-import type { ZodError, ZodType } from 'zod';
+import { ZodError, ZodType } from 'zod';
+import { AnyPath } from '../path';
 
 type MaybeErrors = ZodError | null;
 
+function createErrorParser<T>(schema: ZodType<T>, pathPrefix: AnyPath) {
+	return async (value: T) => {
+		const parseResult = await schema.safeParseAsync(value);
+		if (parseResult.success) return null;
+		const errors = parseResult.error;
+		if (pathPrefix.length === 0) return errors;
+		return new ZodError(
+			errors.errors.map((issue) => ({
+				...issue,
+				path: [...pathPrefix, ...issue.path],
+			}))
+		);
+	};
+}
+
 export function createErrorsAtom<T>(
 	target: Atom<T>,
-	schema: ZodType<T>
+	schema: ZodType<T>,
+	pathPrefix: AnyPath = []
 ): Atom<Loadable<MaybeErrors>> {
-	return loadable(
-		atom(async (get) => {
-			const parseResult = await schema.safeParseAsync(get(target));
-			if (parseResult.success) return null;
-			return parseResult.error;
-		})
-	);
+	const errorParser = createErrorParser(schema, pathPrefix);
+	return loadable(atom((get) => errorParser(get(target))));
 }
 
 export function createTriggeredErrorsAtom<T>(
 	target: Atom<T>,
-	schema: ZodType<T>
+	schema: ZodType<T>,
+	pathPrefix: AnyPath = []
 ): [Atom<Loadable<MaybeErrors>>, WritableAtom<void, [], void>] {
 	const errors = atom<Promise<MaybeErrors>>(Promise.resolve(null));
 
+	const errorParser = createErrorParser(schema, pathPrefix);
 	const writable = atom<void, [], void>(void 0, (get, set) => {
-		set(
-			errors,
-			(async () => {
-				const value = get(target);
-				const parseResult = await schema.safeParseAsync(value);
-				if (parseResult.success) return null;
-				return parseResult.error;
-			})()
-		);
+		set(errors, errorParser(get(target)));
 	});
 
 	return [loadable(errors), writable];

--- a/packages/react-jotai-forms/src/internals/getAtomForPath.ts
+++ b/packages/react-jotai-forms/src/internals/getAtomForPath.ts
@@ -19,8 +19,11 @@ export function getValueAtPath<T, TPath extends Path<T>>(
 				input as unknown
 			) as PathValue<T, TPath>;
 		} catch (ex) {
-			console.warn({ input, steps });
-			throw ex;
+			console.warn(
+				'Unable to find a value at the following path; using "undefined"',
+				{ input, steps }
+			);
+			return undefined!;
 		}
 	};
 }

--- a/packages/react-jotai-forms/src/internals/getZodSchemaForPath.ts
+++ b/packages/react-jotai-forms/src/internals/getZodSchemaForPath.ts
@@ -5,7 +5,7 @@ import type {
 	ZodUnion,
 	ZodUnionOptions,
 } from 'zod';
-import { ZodNull } from 'zod';
+import { z, ZodNull } from 'zod';
 import type { AnyPath, Path, PathValue } from '../path';
 
 export function getZodSchemaForPath<T, TPath extends Path<T>>(
@@ -47,11 +47,17 @@ export function getZodSchemaForPath(
 		} else if ('innerType' in (current as ZodOptional<ZodTypeAny>)._def) {
 			return doStep(step, (current as ZodOptional<ZodTypeAny>)._def.innerType);
 		} else {
-			console.error('during', { steps, schema }, 'unable to continue at', {
-				step,
-				current,
-			});
-			throw new Error('Unable to walk zod path; see console');
+			console.warn(
+				'Attempting to resolve schema during',
+				{ steps, schema },
+				'unable to continue at',
+				{
+					step,
+					current,
+				}
+			);
+
+			return z.undefined();
 		}
 	}
 }

--- a/packages/react-jotai-forms/src/internals/useFieldHelpers.ts
+++ b/packages/react-jotai-forms/src/internals/useFieldHelpers.ts
@@ -14,6 +14,7 @@ import type {
 } from './HtmlProps';
 import type { FieldTranslation } from './FieldTranslation';
 import type { ErrorsAtom } from './ErrorsAtom';
+import { AnyPath } from '../path';
 
 export type UseFieldResultFlags = {
 	hasErrors: boolean;
@@ -50,6 +51,8 @@ export type FieldStateCallback<T, TOriginalValue, TDerivedValue> = (
 export type FieldOptions<TValue, TFormFieldValue> = {
 	schema: ZodType<TValue>;
 	mapping: FieldMapping<TValue, TFormFieldValue>;
+	postMappingSchemaPrefix: AnyPath;
+	postMappingSchema: ZodType<TFormFieldValue>;
 	errorStrategy: RegisterErrorStrategy;
 	formEvents: FormEvents;
 	translation: FieldTranslation;
@@ -62,11 +65,13 @@ export type FieldOptions<TValue, TFormFieldValue> = {
 };
 export type UnmappedOptions<TValue> = Partial<FieldOptions<TValue, TValue>> & {
 	mapping?: never;
+	postMappingSchema?: never;
 };
 export type MappedOptions<TValue, TFieldValue> = Partial<
 	FieldOptions<TValue, TFieldValue>
 > & {
 	mapping: FieldMapping<TValue, TFieldValue>;
+	postMappingSchema?: ZodType<TFieldValue>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/react-jotai-forms/src/types.ts
+++ b/packages/react-jotai-forms/src/types.ts
@@ -10,3 +10,7 @@ export type {
 	ControlledHtmlProps,
 } from './internals/HtmlProps';
 export type { UseFormResult } from './internals/UseFormResult';
+export type {
+	UseFieldsResult,
+	UseFormResultWithFields,
+} from './internals/useFormHelpers';

--- a/packages/react-jotai-forms/src/useForm.specifiedFields.test.tsx
+++ b/packages/react-jotai-forms/src/useForm.specifiedFields.test.tsx
@@ -1,0 +1,248 @@
+import { z } from 'zod';
+import { useForm } from './useForm';
+import JotaiInput from '@principlestudios/react-jotai-form-components/input';
+import { UseFormResultWithFields } from './types';
+import {
+	RenderResult,
+	fireEvent,
+	render,
+	renderHook,
+} from '@testing-library/react';
+import { fastWaitFor } from './test/fastWaitFor';
+import { waitForErrors } from './test/waitForErrors';
+
+const myFormSchema = z.object({
+	name: z.string(),
+});
+type MyForm = z.infer<typeof myFormSchema>;
+type ComponentProps = { onSubmit: (data: MyForm) => void };
+
+const nameSchema = z.string().min(3).max(10);
+
+const defaultValue: MyForm = {
+	name: '',
+};
+
+describe('useForm, specifiedFields', () => {
+	function translation(key: string) {
+		return `translate: ${key}`;
+	}
+
+	let useFormResult: UseFormResultWithFields<
+		MyForm,
+		{
+			readonly name: readonly ['name'];
+		}
+	>;
+	let submitSpy: jest.Mock<void, [MyForm]>;
+	let rendered: RenderResult;
+	let renderCount = 0;
+
+	beforeEach(() => {
+		renderCount = 0;
+		submitSpy = jest.fn();
+	});
+
+	function FormPresentation({
+		form,
+		onSubmit,
+	}: ComponentProps & {
+		form: UseFormResultWithFields<
+			MyForm,
+			{
+				readonly name: readonly ['name'];
+			}
+		>;
+	}) {
+		return (
+			<form
+				onSubmit={form.handleSubmit((v) => {
+					onSubmit(v);
+				})}
+			>
+				<JotaiInput {...form.fields.name.htmlProps()} />
+				<button type="submit">Submit</button>
+			</form>
+		);
+	}
+
+	it('overrides schema for the field', () => {
+		const formHookResult = renderHook(() =>
+			useForm({
+				schema: myFormSchema,
+				defaultValue,
+				translation,
+				fields: {
+					name: { path: ['name'], schema: nameSchema },
+				},
+			})
+		);
+		const form = formHookResult.result.current;
+		expect(form.fields.name).not.toBe(undefined);
+		expect(form.fields.name.schema).toBe(nameSchema);
+	});
+
+	describe('with no field schema', () => {
+		function MyFormComponent({ onSubmit }: ComponentProps) {
+			const form = useForm({
+				schema: myFormSchema,
+				defaultValue,
+				translation,
+				fields: {
+					name: ['name'],
+				},
+			});
+			useFormResult = form;
+			renderCount++;
+
+			return <FormPresentation form={form} onSubmit={onSubmit} />;
+		}
+
+		beforeEach(() => {
+			rendered = render(<MyFormComponent onSubmit={submitSpy} />);
+		});
+
+		it('initializes the form to its defaults', () => {
+			expect(useFormResult.get()).toBe(defaultValue);
+			expect(renderCount).toBe(1);
+		});
+
+		it('can submit the default values', async () => {
+			const submitButton = rendered.queryByRole('button')!;
+			fireEvent.click(submitButton);
+
+			await fastWaitFor(() => expect(submitSpy).toBeCalled());
+			expect(submitSpy).toBeCalledWith<[MyForm]>(defaultValue);
+		});
+
+		standardUpdateAndSubmitTests();
+	});
+
+	describe('with validation only on field', () => {
+		function MyFormComponent({ onSubmit }: ComponentProps) {
+			const form = useForm({
+				schema: myFormSchema,
+				defaultValue,
+				translation,
+				fields: {
+					name: { path: ['name'], schema: nameSchema },
+				},
+			});
+			useFormResult = form;
+			renderCount++;
+
+			return <FormPresentation form={form} onSubmit={onSubmit} />;
+		}
+
+		beforeEach(() => {
+			rendered = render(<MyFormComponent onSubmit={submitSpy} />);
+		});
+
+		it('initializes the form to its defaults', () => {
+			expect(useFormResult.get()).toBe(defaultValue);
+			expect(renderCount).toBe(1);
+		});
+
+		it('does not have error messages initially', async () => {
+			const loadedErrors = await waitForErrors(useFormResult.errors);
+			expect(loadedErrors).toBeNull();
+		});
+
+		it('does not have error messages until submit', async () => {
+			const target = rendered.queryByRole('textbox')!;
+			fireEvent.change(target, { target: { value: 'no' } });
+
+			const loadedErrors = await waitForErrors(useFormResult.errors);
+			expect(loadedErrors).toBeNull();
+		});
+
+		it('gets error messages after submit', async () => {
+			const submitButton = rendered.queryByRole('button')!;
+			fireEvent.click(submitButton);
+
+			const loadedErrors = (await waitForErrors(
+				useFormResult.fields.name.errors
+			))!;
+			expect(loadedErrors.issues[0].code).toBe('too_small');
+			expect(loadedErrors.issues[0].path).toStrictEqual(['name']);
+		});
+
+		it('updates messages after submit on blur', async () => {
+			const submitButton = rendered.queryByRole('button')!;
+			fireEvent.click(submitButton);
+			// error message at this time is too_small
+
+			const target = rendered.queryByRole('textbox')!;
+			fireEvent.change(target, { target: { value: 'this value is too long' } });
+			fireEvent.blur(target);
+
+			const loadedErrors = (await waitForErrors(
+				useFormResult.fields.name.errors
+			))!;
+			expect(loadedErrors.issues[0].code).toBe('too_big');
+		});
+
+		it('can submit the default values because validation is not on the root schema', async () => {
+			const submitButton = rendered.queryByRole('button')!;
+			fireEvent.click(submitButton);
+
+			const loadedErrors = await waitForErrors(useFormResult.errors);
+			expect(loadedErrors).toBeNull();
+			expect(submitSpy).toBeCalled();
+		});
+
+		standardUpdateAndSubmitTests();
+	});
+
+	function standardUpdateAndSubmitTests() {
+		describe('when the user updates the field', () => {
+			beforeEach(() => {
+				const target = rendered.queryByRole('textbox')!;
+				fireEvent.change(target, { target: { value: 'foobar' } });
+			});
+
+			it('receives form updates', () => {
+				expect(useFormResult.get().name).toBe('foobar');
+			});
+
+			it('does not rerender', () => {
+				expect(renderCount).toBe(1);
+			});
+
+			it('can submit the new value', async () => {
+				const submitButton = rendered.queryByRole('button')!;
+				fireEvent.click(submitButton);
+
+				await fastWaitFor(() => expect(submitSpy).toBeCalled());
+				expect(submitSpy).toBeCalledWith<[MyForm]>({
+					name: 'foobar',
+				});
+			});
+		});
+
+		describe('when updated via the form result', () => {
+			beforeEach(() => {
+				useFormResult.set({ name: 'foobar' });
+			});
+
+			it('updates the input', () => {
+				const target = rendered.queryByRole('textbox')!;
+				expect(target).toHaveProperty('value', 'foobar');
+			});
+
+			it('does not rerender', () => {
+				expect(renderCount).toBe(1);
+			});
+
+			it('can submit the new value', async () => {
+				const submitButton = rendered.queryByRole('button')!;
+				fireEvent.click(submitButton);
+
+				await fastWaitFor(() => expect(submitSpy).toBeCalled());
+				expect(submitSpy).toBeCalledWith<[MyForm]>({
+					name: 'foobar',
+				});
+			});
+		});
+	}
+});


### PR DESCRIPTION
Mapped objects did not leverage schemas for child fields. As a result, mappings that fundamentally changed object structures (records to arrays, for instance) could not be used, throwing errors because the schema could not be traversed.