### PR TITLE
Support form atom storage

### DIFF
--- a/packages/react-jotai-forms/package.json
+++ b/packages/react-jotai-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@principlestudios/react-jotai-forms",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"description": "👻 React Forms using Jotai",
 	"main": "dist/index.js",
 	"module": "dist/mjs/index.js",

--- a/packages/react-jotai-forms/src/internals/UseFormResult.ts
+++ b/packages/react-jotai-forms/src/internals/UseFormResult.ts
@@ -19,7 +19,6 @@ export interface UseFormResult<T> {
 	schema: ZodType<T>;
 	errors: Atom<Loadable<ZodError<T> | null>>;
 	formEvents: FormEvents;
-	defaultValue: React.MutableRefObject<T>;
 	disabledFields: FieldStateAtom<boolean>;
 	readOnlyFields: FieldStateAtom<boolean>;
 	formTranslation: (this: void, field: string) => string;

--- a/packages/react-jotai-forms/src/useForm.ts
+++ b/packages/react-jotai-forms/src/useForm.ts
@@ -17,32 +17,33 @@ import {
 } from './internals/useFormHelpers';
 import { StandardWritableAtom } from './internals/StandardWritableAtom';
 
-export function useForm<T>(options: FormOptions<T>): UseFormResult<T>;
+export function useForm<T>(
+	options: FormOptions<T> & { defaultValue: T }
+): UseFormResult<T>;
 export function useForm<T, const TFields extends FieldsConfig<T>>(
-	options: FormOptions<T> & FormFieldsOptions<T, TFields>
+	options: FormOptions<T> & { defaultValue: T } & FormFieldsOptions<T, TFields>
 ): UseFormResultWithFields<T, TFields>;
 export function useForm<T>({
 	defaultValue,
 	...options
-}: FormOptions<T> & Partial<FormFieldsOptions<T, FieldsConfig<T>>>):
-	| UseFormResult<T>
-	| UseFormResultWithFields<T, FieldsConfig<T>> {
+}: FormOptions<T> & { defaultValue: T } & Partial<
+		FormFieldsOptions<T, FieldsConfig<T>>
+	>): UseFormResult<T> | UseFormResultWithFields<T, FieldsConfig<T>> {
 	const formAtom = useConstant(() => atom(defaultValue));
 	return useFormAtom(formAtom, options);
 }
 
 export function useFormAtom<T>(
 	formAtom: StandardWritableAtom<T> & { init: T },
-	options: Omit<FormOptions<T>, 'defaultValue'>
+	options: FormOptions<T>
 ): UseFormResult<T>;
 export function useFormAtom<T, const TFields extends FieldsConfig<T>>(
 	formAtom: StandardWritableAtom<T> & { init: T },
-	options: Omit<FormOptions<T> & FormFieldsOptions<T, TFields>, 'defaultValue'>
+	options: FormOptions<T> & FormFieldsOptions<T, TFields>
 ): UseFormResultWithFields<T, TFields>;
 export function useFormAtom<T>(
 	formAtom: StandardWritableAtom<T> & { init: T },
-	options: Omit<FormOptions<T>, 'defaultValue'> &
-		Partial<FormFieldsOptions<T, FieldsConfig<T>>>
+	options: FormOptions<T> & Partial<FormFieldsOptions<T, FieldsConfig<T>>>
 ): UseFormResult<T> | UseFormResultWithFields<T, FieldsConfig<T>> {
 	const store = useStore();
 	return useConstant(
@@ -55,15 +56,6 @@ export function useFormAtom<T>(
 			);
 			const atomFamily = createPathAtomFamily(formAtom);
 
-			const defaultValue = {
-				get current(): T {
-					return formAtom.init;
-				},
-				set current(value) {
-					formAtom.init = value;
-				},
-			};
-
 			const result = buildFormResult<T>({
 				pathPrefix: [],
 				translationPath: [],
@@ -74,7 +66,6 @@ export function useFormAtom<T>(
 				formEvents,
 				errorStrategy: strategy,
 				formTranslation: options.translation,
-				defaultValue,
 				disabledFields: toAtomFieldState(options.disabled ?? false),
 				readOnlyFields: toAtomFieldState(options.readOnly ?? false),
 			});

--- a/packages/react-jotai-forms/src/useFormFields.ts
+++ b/packages/react-jotai-forms/src/useFormFields.ts
@@ -14,10 +14,7 @@ import type {
 import { useConstant } from './internals/useConstant';
 import type { Path } from './path';
 
-export function useFormFields<
-	T extends Objectish,
-	const TFields extends FieldsConfig<T>,
->(
+export function useFormFields<T, const TFields extends FieldsConfig<T>>(
 	form: UseFormResult<T>,
 	fields: TFields
 ): UseFieldsResult<T, TFields>['fields'] {
@@ -25,11 +22,7 @@ export function useFormFields<
 }
 
 // TODO - accept function callbacks
-export function useFormField<
-	T extends Objectish,
-	TPath extends Path<T>,
-	TValue,
->(
+export function useFormField<T, TPath extends Path<T>, TValue>(
 	form: UseFormResult<T>,
 	field: FieldConfig<T, TPath, TValue>
 ): FormFieldReturnTypeFromConfig<


### PR DESCRIPTION
Adds `useFormAtom` that uses the current form state from an atom rather than creating a new one.