### PR TITLE
API Simplification: translation

### DIFF
--- a/packages/jotai-react-signals/package.json
+++ b/packages/jotai-react-signals/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@principlestudios/jotai-react-signals",
-	"version": "0.5.1",
+	"version": "0.6.0",
 	"description": "👻 React signals using Jotai",
 	"main": "dist/index.js",
 	"module": "dist/mjs/index.js",

--- a/packages/jotai-react-signals/src/internals/withSignal.ts
+++ b/packages/jotai-react-signals/src/internals/withSignal.ts
@@ -9,6 +9,7 @@ import {
 	memo,
 } from 'react';
 import { isAtom } from '@principlestudios/jotai-utilities/isAtom';
+import { currentValue } from '@principlestudios/jotai-utilities/currentValue';
 import {
 	mapStyle,
 	type Mapping,
@@ -71,7 +72,7 @@ function toPropsObj<
 					Object.fromEntries(
 						Object.entries(value as CSSProperties).map(([k, v]) => [
 							k,
-							isAtom(v) ? get(v) : v,
+							currentValue(v),
 						])
 					),
 				];

--- a/packages/react-jotai-forms/package.json
+++ b/packages/react-jotai-forms/package.json
@@ -32,10 +32,8 @@
 		}
 	},
 	"scripts": {
-		"prebuild": "pwsh ./scripts/pre-build.ps1 -ExecutionPolicy Unrestricted -NoProfile",
 		"build": "npm run build:dts && rollup -c",
 		"build:dts": "tsc --build --force tsconfig.dts.json",
-		"postbuild": "pwsh ./scripts/post-build.ps1 -ExecutionPolicy Unrestricted -NoProfile",
 		"test": "jest",
 		"test:watch": "jest --watch",
 		"lint": "npm run typecheck && npm run eslint && npm run prettier",

--- a/packages/react-jotai-forms/package.json
+++ b/packages/react-jotai-forms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@principlestudios/react-jotai-forms",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "👻 React Forms using Jotai",
 	"main": "dist/index.js",
 	"module": "dist/mjs/index.js",

--- a/packages/react-jotai-forms/react-jotai-forms.esproj
+++ b/packages/react-jotai-forms/react-jotai-forms.esproj
@@ -5,4 +5,8 @@
 		<ProjectReference Include="../jotai-utilities/jotai-utilities.esproj" />
 		<ProjectReference Include="../react-jotai-form-components/react-jotai-form-components.esproj" />
 	</ItemGroup>
+
+	<Target Name="PreNodeBuild" BeforeTargets="NodeBuild">
+		<RemoveDir Directories="dist" />
+	</Target>
 </Project>

--- a/packages/react-jotai-forms/readme.md
+++ b/packages/react-jotai-forms/readme.md
@@ -41,11 +41,9 @@ type FormDemoProps = {
 };
 
 export function FormDemo({ onSubmit }: FormDemoProps) {
-	const { t } = useTranslation(['demo']);
 	const form = useForm({
 		schema: myFormSchema,
 		defaultValue,
-		translation: t,
 		fields: {
 			name: ['name'],
 		},

--- a/packages/react-jotai-forms/scripts/post-build.ps1
+++ b/packages/react-jotai-forms/scripts/post-build.ps1
@@ -1,9 +1,0 @@
-#!/usr/bin/env pwsh
-
-Push-Location "$PSScriptRoot/.."
-try {
-	# '{ "type": "commonjs" }' | Out-File dist/cjs/package.json
-	# '{ "type": "module" }' | Out-File dist/mjs/package.json
-} finally {
-	Pop-Location
-}

--- a/packages/react-jotai-forms/scripts/pre-build.ps1
+++ b/packages/react-jotai-forms/scripts/pre-build.ps1
@@ -1,9 +1,0 @@
-#!/usr/bin/env pwsh
-
-Push-Location "$PSScriptRoot/.."
-try {
-	# Remove old dist folder
-	Remove-Item -r dist -ErrorAction SilentlyContinue
-} finally {
-	Pop-Location
-}

--- a/packages/react-jotai-forms/src/internals/FieldTranslation.ts
+++ b/packages/react-jotai-forms/src/internals/FieldTranslation.ts
@@ -1,9 +1,0 @@
-export type FieldTranslatablePart =
-	| ['label']
-	| ['description']
-	| ['errors', string]
-	| string;
-export type FieldTranslation = (
-	this: void,
-	part: FieldTranslatablePart
-) => string;

--- a/packages/react-jotai-forms/src/internals/UseFormResult.ts
+++ b/packages/react-jotai-forms/src/internals/UseFormResult.ts
@@ -21,7 +21,6 @@ export interface UseFormResult<T> {
 	formEvents: FormEvents;
 	disabledFields: FieldStateAtom<boolean>;
 	readOnlyFields: FieldStateAtom<boolean>;
-	formTranslation: (this: void, field: string) => string;
 	field<TPath extends Path<T>>(
 		this: void,
 		path: TPath

--- a/packages/react-jotai-forms/src/internals/fieldStateTracking.ts
+++ b/packages/react-jotai-forms/src/internals/fieldStateTracking.ts
@@ -3,6 +3,7 @@ import { atom } from 'jotai';
 import type { AnyPath } from '../path';
 import { produce } from 'immer';
 import { isAtom } from '@principlestudios/jotai-utilities/isAtom';
+import { currentValue } from '@principlestudios/jotai-utilities/currentValue';
 
 export type SetStateNoInitialAction<T> = (prev: T | undefined) => T;
 export type NoInitialWritableAtom<Value> = WritableAtom<
@@ -30,11 +31,11 @@ export function toWritableAtom<T extends FieldStatePrimitive>(
 	return atom(
 		(get) => {
 			const temp = get(fieldState);
-			return isAtom(temp) ? get(temp) : temp;
+			return currentValue(temp);
 		},
 		(get, set, action) => {
 			let temp = get(fieldState);
-			temp = isAtom(temp) ? get(temp) : temp;
+			temp = currentValue(temp);
 			set(
 				fieldState,
 				typeof action === 'function' ? action(temp) : () => action

--- a/packages/react-jotai-forms/src/internals/toInternalFieldAtom.ts
+++ b/packages/react-jotai-forms/src/internals/toInternalFieldAtom.ts
@@ -62,12 +62,12 @@ export function toInternalFieldAtom<
 export function toInternalFieldAtom<TValue, TFieldValue>(
 	store: ReturnType<typeof useStore>,
 	fieldValueAtom: StandardWritableAtom<TValue>,
-	options: Partial<FieldOptions<TValue, TFieldValue>>
+	options: FieldOptions<TValue, TFieldValue>
 ): UseFieldResult<TFieldValue>;
 export function toInternalFieldAtom<TValue, TFieldValue>(
 	store: ReturnType<typeof useStore>,
 	fieldValueAtom: StandardWritableAtom<TValue>,
-	options: Partial<FieldOptions<TValue, TFieldValue>>
+	options: FieldOptions<TValue, TFieldValue>
 ): UseFieldResult<TFieldValue> {
 	const fieldEvents = new FieldEvents(options.formEvents);
 	const mapping: FieldMapping<TValue, TFieldValue> =
@@ -157,7 +157,6 @@ export function toInternalFieldAtom<TValue, TFieldValue>(
 		getValue: () => store.get(formValueAtom),
 		schema: options.postMappingSchema ?? schema,
 		errors,
-		translation: options.translation,
 		onChange(v: TFieldValue | ((prev: TFieldValue) => TFieldValue)) {
 			fieldEvents.dispatchEvent(FieldEvents.Change);
 			setValue(v);
@@ -193,7 +192,7 @@ export function toInternalFieldAtom<TValue, TFieldValue>(
 			},
 			// TODO - should we require a post-mapping schema?
 			postMappingSchema: undefined,
-		} satisfies Partial<FieldOptions<TValue, TNew>>;
+		} satisfies FieldOptions<TValue, TNew>;
 		const result = toInternalFieldAtom(store, fieldValueAtom, newOptions);
 		mappings.set(newMapping, result);
 		return result;

--- a/packages/react-jotai-forms/src/internals/useFieldHelpers.ts
+++ b/packages/react-jotai-forms/src/internals/useFieldHelpers.ts
@@ -12,13 +12,11 @@ import type {
 	ControlledHtmlProps,
 	InputHtmlProps,
 } from './HtmlProps';
-import type { FieldTranslation } from './FieldTranslation';
 import type { ErrorsAtom } from './ErrorsAtom';
 import { AnyPath } from '../path';
 
 export type UseFieldResultFlags = {
 	hasErrors: boolean;
-	hasTranslations: boolean;
 };
 export type ToHtmlInputProps<TInputValue> = TInputValue extends string
 	? () => InputHtmlProps
@@ -49,21 +47,20 @@ export type FieldStateCallback<T, TOriginalValue, TDerivedValue> = (
 ) => T;
 
 export type FieldOptions<TValue, TFormFieldValue> = {
-	schema: ZodType<TValue>;
-	mapping: FieldMapping<TValue, TFormFieldValue>;
-	postMappingSchemaPrefix: AnyPath;
-	postMappingSchema: ZodType<TFormFieldValue>;
-	errorStrategy: RegisterErrorStrategy;
-	formEvents: FormEvents;
-	translation: FieldTranslation;
-	disabled:
+	schema?: ZodType<TValue>;
+	mapping?: FieldMapping<TValue, TFormFieldValue>;
+	postMappingSchemaPrefix?: AnyPath;
+	postMappingSchema?: ZodType<TFormFieldValue>;
+	errorStrategy?: RegisterErrorStrategy;
+	formEvents?: FormEvents;
+	disabled?:
 		| FieldStateAtom<boolean>
 		| FieldStateCallback<PerFieldState<boolean>, TValue, TFormFieldValue>;
-	readOnly:
+	readOnly?:
 		| FieldStateAtom<boolean>
 		| FieldStateCallback<PerFieldState<boolean>, TValue, TFormFieldValue>;
 };
-export type UnmappedOptions<TValue> = Partial<FieldOptions<TValue, TValue>> & {
+export type UnmappedOptions<TValue> = FieldOptions<TValue, TValue> & {
 	mapping?: never;
 	postMappingSchema?: never;
 };
@@ -78,7 +75,4 @@ export type MappedOptions<TValue, TFieldValue> = Partial<
 type AnyFieldOptions = FieldOptions<any, any>;
 export type Flags<TOptions extends Partial<AnyFieldOptions>> = {
 	hasErrors: 'schema' extends keyof TOptions ? true : false;
-	hasTranslations: TOptions['translation'] extends FieldTranslation
-		? true
-		: false;
 };

--- a/packages/react-jotai-forms/src/types.ts
+++ b/packages/react-jotai-forms/src/types.ts
@@ -2,7 +2,6 @@ export type { FieldsConfig } from './internals/field-config-types';
 export type { PerFieldState } from './internals/fieldStateTracking';
 export type { ErrorsAtom } from './internals/ErrorsAtom';
 export type { FieldMapping } from './internals/FieldMapping';
-export type { FieldTranslation } from './internals/FieldTranslation';
 export type { FormFieldReturnType } from './internals/FormFieldReturnType';
 export type {
 	InputHtmlProps,

--- a/packages/react-jotai-forms/src/types.ts
+++ b/packages/react-jotai-forms/src/types.ts
@@ -13,4 +13,5 @@ export type { UseFormResult } from './internals/UseFormResult';
 export type {
 	UseFieldsResult,
 	UseFormResultWithFields,
+	DefaultFormFieldResultFlags,
 } from './internals/useFormHelpers';

--- a/packages/react-jotai-forms/src/useField.test.tsx
+++ b/packages/react-jotai-forms/src/useField.test.tsx
@@ -8,11 +8,7 @@ import { integerMapping } from './test/integerMapping';
 describe('useField', () => {
 	describe('with a basic number construction', () => {
 		let hook: {
-			current: UseUpdatableFieldResult<
-				number,
-				number,
-				{ hasErrors: boolean; hasTranslations: boolean }
-			>;
+			current: UseUpdatableFieldResult<number, number, { hasErrors: boolean }>;
 		};
 		let store: ReturnType<typeof getDefaultStore>;
 		beforeEach(() => {
@@ -46,7 +42,7 @@ describe('useField', () => {
 		type HookType = UseUpdatableFieldResult<
 			string,
 			string,
-			{ hasErrors: false; hasTranslations: false }
+			{ hasErrors: false }
 		>;
 		let hook: { current: HookType };
 		let store: ReturnType<typeof getDefaultStore>;
@@ -60,7 +56,6 @@ describe('useField', () => {
 		// TS tests to verify that optional properties were not provided
 		true satisfies HookType['errors'] extends undefined ? true : false;
 		true satisfies HookType['schema'] extends undefined ? true : false;
-		true satisfies HookType['translation'] extends undefined ? true : false;
 
 		it('creates a basic field for easy use with a default value', () => {
 			expect(store.get(hook.current.fieldValue)).toBe('foo');
@@ -80,13 +75,10 @@ describe('useField', () => {
 			expect(store.get(hook.current.fieldValue)).toBe('foobar');
 		});
 
-		it('adjust TS types to indicate no errors or translations will work', () => {
+		it('adjust TS types to indicate no errors work', () => {
 			// Errors were not defined, so these should be undefined
 			hook.current.errors satisfies undefined;
 			hook.current.schema satisfies undefined;
-
-			// Translations were not defined, so the translation function should be undefined
-			hook.current.translation satisfies undefined;
 		});
 
 		describe('when rendered to an input element', () => {
@@ -171,11 +163,7 @@ describe('useField', () => {
 
 	describe('with a basic number construction', () => {
 		let hook: {
-			current: UseUpdatableFieldResult<
-				number,
-				string,
-				{ hasErrors: boolean; hasTranslations: boolean }
-			>;
+			current: UseUpdatableFieldResult<number, string, { hasErrors: boolean }>;
 		};
 		let store: ReturnType<typeof getDefaultStore>;
 		beforeEach(() => {

--- a/packages/react-jotai-forms/src/useField.ts
+++ b/packages/react-jotai-forms/src/useField.ts
@@ -13,7 +13,6 @@ import type {
 	ToHtmlProps,
 } from './internals/useFieldHelpers';
 import type { ErrorsAtom } from './internals/ErrorsAtom';
-import type { FieldTranslation } from './internals/FieldTranslation';
 import type { FieldMapping } from './internals/FieldMapping';
 import type { UseFieldResultFlags } from './internals/useFieldHelpers';
 import type { IfTrueThenProp } from './internals/type-helpers';
@@ -63,14 +62,7 @@ export type UseFieldResult<
 		/** An atom representing field errors. (Conditional property, only present if a schema was provided when the form or field was set up.) */
 		errors: ErrorsAtom;
 	}
-> &
-	IfTrueThenProp<
-		TFlags['hasTranslations'],
-		{
-			/** The translation information for the field. (Conditional property, only present if a translation function was provided when the form or field was set up.) */
-			translation: FieldTranslation;
-		}
-	>;
+>;
 
 export type UseUpdatableFieldResult<
 	TValue,
@@ -83,7 +75,7 @@ export type UseUpdatableFieldResult<
 
 function useInternalFieldAtom<TValue, TFieldValue>(
 	fieldValueAtom: StandardWritableAtom<TValue>,
-	options: Partial<FieldOptions<TValue, TFieldValue>> = {}
+	options: FieldOptions<TValue, TFieldValue>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): UseFieldResult<TFieldValue, any> {
 	const store = useStore();
@@ -116,7 +108,7 @@ export function useField<
 	: UseUpdatableFieldResult<TValue, TValue, Flags<TOptions>>;
 export function useField<TValue, TFieldValue>(
 	defaultValue: TValue,
-	options: Partial<FieldOptions<TValue, TFieldValue>> = {}
+	options: FieldOptions<TValue, TFieldValue>
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): UseUpdatableFieldResult<TValue, TFieldValue, any> {
 	const fieldValueAtom = useConstant(() => atom<TValue>(defaultValue));

--- a/packages/react-jotai-forms/src/useForm.array.test.tsx
+++ b/packages/react-jotai-forms/src/useForm.array.test.tsx
@@ -22,10 +22,6 @@ const myFormSchemaWithValidation = z
 const defaultValue: MyForm = [''];
 
 describe('useForm, array', () => {
-	function translation(key: string) {
-		return `translate: ${key}`;
-	}
-
 	let useFormResult: UseFormResult<MyForm>;
 	let submitSpy: jest.Mock<void, [MyForm]>;
 	let rendered: RenderResult;
@@ -78,7 +74,6 @@ describe('useForm, array', () => {
 			const form = useForm({
 				schema: myFormSchema,
 				defaultValue,
-				translation,
 			});
 			useFormResult = form;
 			renderCount++;
@@ -113,7 +108,6 @@ describe('useForm, array', () => {
 			const form = useForm({
 				schema: myFormSchemaWithValidation,
 				defaultValue,
-				translation,
 			});
 			useFormResult = form;
 			renderCount++;
@@ -128,6 +122,10 @@ describe('useForm, array', () => {
 		it('initializes the form to its defaults', () => {
 			expect(useFormResult.get()).toBe(defaultValue);
 			expect(renderCount).toBe(1);
+		});
+
+		it('gets the appropriate translation path', () => {
+			expect(useFormResult.field([0]).translationPath).toEqual([0]);
 		});
 
 		it('does not have error messages initially', async () => {

--- a/packages/react-jotai-forms/src/useForm.inlineFields.test.tsx
+++ b/packages/react-jotai-forms/src/useForm.inlineFields.test.tsx
@@ -21,10 +21,6 @@ const defaultValue: MyForm = {
 };
 
 describe('useForm, inlineFields', () => {
-	function translation(key: string) {
-		return `translate: ${key}`;
-	}
-
 	let useFormResult: UseFormResult<MyForm>;
 	let submitSpy: jest.Mock<void, [MyForm]>;
 	let rendered: RenderResult;
@@ -56,7 +52,6 @@ describe('useForm, inlineFields', () => {
 			const form = useForm({
 				schema: myFormSchema,
 				defaultValue,
-				translation,
 			});
 			useFormResult = form;
 			renderCount++;
@@ -71,6 +66,10 @@ describe('useForm, inlineFields', () => {
 		it('initializes the form to its defaults', () => {
 			expect(useFormResult.get()).toBe(defaultValue);
 			expect(renderCount).toBe(1);
+		});
+
+		it('gets the appropriate translation path', () => {
+			expect(useFormResult.field(['name']).translationPath).toEqual(['name']);
 		});
 
 		it('can submit the default values', async () => {
@@ -89,7 +88,6 @@ describe('useForm, inlineFields', () => {
 			const form = useForm({
 				schema: myFormSchemaWithValidation,
 				defaultValue,
-				translation,
 			});
 			useFormResult = form;
 			renderCount++;

--- a/packages/react-jotai-forms/src/useForm.nested-object.test.tsx
+++ b/packages/react-jotai-forms/src/useForm.nested-object.test.tsx
@@ -37,10 +37,6 @@ const defaultValue: MyForm = {
 };
 
 describe('useForm, nested-object', () => {
-	function translation(key: string) {
-		return `translate: ${key}`;
-	}
-
 	let useFormResult: UseFormResult<MyForm>;
 	let submitSpy: jest.Mock<void, [MyForm]>;
 	let rendered: RenderResult;
@@ -97,7 +93,6 @@ describe('useForm, nested-object', () => {
 			const form = useForm({
 				schema: myFormSchema,
 				defaultValue,
-				translation,
 				fields: {
 					address: ['address'],
 				},
@@ -123,6 +118,18 @@ describe('useForm, nested-object', () => {
 			expect(renderCount).toBe(1);
 		});
 
+		it('gets the appropriate translation path', () => {
+			expect(useFormResult.field(['address']).translationPath).toEqual([
+				'address',
+			]);
+		});
+
+		it('gets the appropriate translation path when accessing deep fields', () => {
+			expect(
+				useFormResult.field(['address']).field(['city']).translationPath
+			).toEqual(['address', 'city']);
+		});
+
 		it('can submit the default values', async () => {
 			const submitButton = rendered.queryByRole('button', {
 				name: 'Submit',
@@ -142,7 +149,6 @@ describe('useForm, nested-object', () => {
 			const form = useForm({
 				schema: myFormSchemaWithValidation,
 				defaultValue,
-				translation,
 				fields: {
 					address: ['billingAddress'],
 				},
@@ -181,7 +187,6 @@ describe('useForm, nested-object', () => {
 			const form = useForm({
 				schema: myFormSchemaWithValidation,
 				defaultValue,
-				translation,
 				fields: {
 					address: ['address'],
 				},

--- a/packages/react-jotai-forms/src/useForm.primitive.test.tsx
+++ b/packages/react-jotai-forms/src/useForm.primitive.test.tsx
@@ -18,10 +18,6 @@ const myFormSchemaWithValidation = z
 const defaultValue: MyForm = '';
 
 describe('useForm, primitive', () => {
-	function translation(key: string) {
-		return `translate: ${key}`;
-	}
-
 	let useFormResult: UseFormResult<MyForm>;
 	let submitSpy: jest.Mock<void, [MyForm]>;
 	let rendered: RenderResult;
@@ -53,7 +49,6 @@ describe('useForm, primitive', () => {
 			const form = useForm({
 				schema: myFormSchema,
 				defaultValue,
-				translation,
 			});
 			useFormResult = form;
 			renderCount++;
@@ -68,6 +63,10 @@ describe('useForm, primitive', () => {
 		it('initializes the form to its defaults', () => {
 			expect(useFormResult.get()).toBe(defaultValue);
 			expect(renderCount).toBe(1);
+		});
+
+		it('gets the appropriate translation path', () => {
+			expect(useFormResult.field([]).translationPath).toEqual([]);
 		});
 
 		it('can submit the default values', async () => {
@@ -86,7 +85,6 @@ describe('useForm, primitive', () => {
 			const form = useForm({
 				schema: myFormSchemaWithValidation,
 				defaultValue,
-				translation,
 			});
 			useFormResult = form;
 			renderCount++;

--- a/packages/react-jotai-forms/src/useForm.specifiedFields.test.tsx
+++ b/packages/react-jotai-forms/src/useForm.specifiedFields.test.tsx
@@ -24,10 +24,6 @@ const defaultValue: MyForm = {
 };
 
 describe('useForm, specifiedFields', () => {
-	function translation(key: string) {
-		return `translate: ${key}`;
-	}
-
 	let useFormResult: UseFormResultWithFields<
 		MyForm,
 		{
@@ -71,7 +67,6 @@ describe('useForm, specifiedFields', () => {
 			useForm({
 				schema: myFormSchema,
 				defaultValue,
-				translation,
 				fields: {
 					name: { path: ['name'], schema: nameSchema },
 				},
@@ -87,7 +82,6 @@ describe('useForm, specifiedFields', () => {
 			const form = useForm({
 				schema: myFormSchema,
 				defaultValue,
-				translation,
 				fields: {
 					name: ['name'],
 				},
@@ -107,6 +101,10 @@ describe('useForm, specifiedFields', () => {
 			expect(renderCount).toBe(1);
 		});
 
+		it('gets the appropriate translation path', () => {
+			expect(useFormResult.fields.name.translationPath).toEqual(['name']);
+		});
+
 		it('can submit the default values', async () => {
 			const submitButton = rendered.queryByRole('button')!;
 			fireEvent.click(submitButton);
@@ -123,7 +121,6 @@ describe('useForm, specifiedFields', () => {
 			const form = useForm({
 				schema: myFormSchema,
 				defaultValue,
-				translation,
 				fields: {
 					name: { path: ['name'], schema: nameSchema },
 				},

--- a/packages/react-jotai-forms/src/useForm.ts
+++ b/packages/react-jotai-forms/src/useForm.ts
@@ -65,7 +65,6 @@ export function useFormAtom<T>(
 				schema: options.schema,
 				formEvents,
 				errorStrategy: strategy,
-				formTranslation: options.translation,
 				disabledFields: toAtomFieldState(options.disabled ?? false),
 				readOnlyFields: toAtomFieldState(options.readOnly ?? false),
 			});


### PR DESCRIPTION
Translation was only partially supported; because it expected to be using `i18next` but did not allow options to be passed, several issues arose when actually implementing.

These changes ensure the translation path remains, but a translation function is not required; this allows for better support of any translation library, as the docs describe.